### PR TITLE
feat: add post layout with metadata

### DIFF
--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -1,0 +1,54 @@
+---
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
+
+export interface Props {
+  title: string;
+  heroImage?: string;
+  author?: {
+    name?: string;
+    avatar?: string;
+  };
+  publishDate?: string;
+  updatedDate?: string;
+  tags?: string[];
+  readingTime?: string;
+}
+
+const { title, heroImage, author, publishDate, updatedDate, tags = [], readingTime } = Astro.props as Props;
+
+const frontmatter = { title, tableOfContents: false };
+---
+<StarlightPage frontmatter={frontmatter} hasSidebar={false}>
+  {heroImage && (
+    <img src={heroImage} alt={title} style="width:100%;object-fit:cover;" />
+  )}
+  <header style="margin-bottom:1rem;">
+    {(author?.avatar || author?.name) && (
+      <div style="display:flex;align-items:center;gap:0.5rem;">
+        {author?.avatar && (
+          <img src={author.avatar} alt={author.name ?? 'Author'} style="width:40px;height:40px;border-radius:50%;" />
+        )}
+        {author?.name && <span>{author.name}</span>}
+      </div>
+    )}
+    <div style="display:flex;flex-wrap:wrap;gap:0.5rem;font-size:0.875rem;color:var(--sl-color-text-secondary);">
+      {publishDate && (
+        <time datetime={publishDate}>Published {publishDate}</time>
+      )}
+      {updatedDate && (
+        <time datetime={updatedDate}>Updated {updatedDate}</time>
+      )}
+      {readingTime && <span>{readingTime}</span>}
+    </div>
+    {tags.length > 0 && (
+      <ul style="display:flex;gap:0.5rem;margin-top:0.5rem;padding:0;list-style:none;">
+        {tags.map((tag) => (
+          <li style="background:var(--sl-color-gray-2);padding:0.25rem 0.5rem;border-radius:0.25rem;" class="tag">{tag}</li>
+        ))}
+      </ul>
+    )}
+  </header>
+  <article>
+    <slot />
+  </article>
+</StarlightPage>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,5 +1,5 @@
 ---
-import BlogLayout from '../../layouts/BlogLayout.astro';
+import PostLayout from '../../layouts/PostLayout.astro';
 import { getCollection } from 'astro:content';
 
 export async function getStaticPaths() {
@@ -12,12 +12,10 @@ export async function getStaticPaths() {
 
 const { post } = Astro.props;
 const { Content } = await post.render();
+
+const wordCount = post.body ? post.body.split(/\s+/g).length : 0;
+const readingTime = `${Math.ceil(wordCount / 200)} min read`;
 ---
-<BlogLayout title={post.data.title}>
-  <article>
-    {post.data.publishDate && (
-      <p><time datetime={post.data.publishDate}>{post.data.publishDate}</time></p>
-    )}
-    <Content />
-  </article>
-</BlogLayout>
+<PostLayout {...post.data} readingTime={readingTime}>
+  <Content />
+</PostLayout>


### PR DESCRIPTION
## Summary
- add `PostLayout` to show hero image, author details, dates, tags, and reading time
- update blog page to use new layout and compute reading time

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_688fd7bbcbd08322857bf871f9701035