### PR TITLE
feat: add blog schema and frontmatter fields

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,8 +1,19 @@
-import { defineCollection } from 'astro:content';
+import { defineCollection, z } from 'astro:content';
 import { docsLoader } from '@astrojs/starlight/loaders';
 import { docsSchema } from '@astrojs/starlight/schema';
 
 export const collections = {
         docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
-        blog: defineCollection({ schema: docsSchema() }),
+        blog: defineCollection({
+                schema: z.object({
+                        title: z.string(),
+                        description: z.string(),
+                        publishDate: z.date(),
+                        updatedDate: z.date(),
+                        author: z.string(),
+                        category: z.string(),
+                        tags: z.array(z.string()),
+                        coverImage: z.string(),
+                }),
+        }),
 };

--- a/src/content/blog/example.md
+++ b/src/content/blog/example.md
@@ -2,6 +2,13 @@
 title: Example Blog Post
 description: This is an example blog post to test routing.
 publishDate: 2025-08-02
+updatedDate: 2025-08-02
+author: Tyler Staut
+category: Example
+tags:
+  - example
+  - blog
+coverImage: ../../assets/tyler.png
 ---
 
 # Example Blog Post


### PR DESCRIPTION
## Summary
- define explicit Zod schema for `blog` collection with metadata fields
- supply required frontmatter in existing blog post

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_688fd7ad4b008322b96fb9f1ac22b4c7