### PR TITLE
feat: generate blog RSS feed

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,6 +12,12 @@ export default defineConfig({
       social: [
         { icon: 'github', label: 'GitHub', href: 'https://github.com/Tyler-Staut' },
       ],
+      head: [
+        {
+          tag: 'link',
+          attrs: { rel: 'alternate', type: 'application/rss+xml', href: '/rss.xml' },
+        },
+      ],
       sidebar: [
         {
           label: 'Notes',

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -11,5 +11,30 @@ const { title } = Astro.props;
 const frontmatter = { title, tableOfContents: false };
 ---
 <StarlightPage frontmatter={frontmatter} hasSidebar={false}>
+  <p class="rss-subscribe">
+    <a href="/rss.xml" target="_blank" rel="noopener">
+      <img
+        src="https://cdn.jsdelivr.net/npm/simple-icons@latest/icons/rss.svg"
+        alt="RSS"
+        width="16"
+        height="16"
+      />
+      Subscribe via RSS
+    </a>
+  </p>
   <slot />
 </StarlightPage>
+
+<style>
+  .rss-subscribe {
+    text-align: right;
+    margin-bottom: 1rem;
+  }
+
+  .rss-subscribe a {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    text-decoration: none;
+  }
+</style>

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -12,7 +12,7 @@ const frontmatter = { title, tableOfContents: false };
 ---
 <StarlightPage frontmatter={frontmatter} hasSidebar={false}>
   <p class="rss-subscribe">
-    <a href="/rss.xml" target="_blank" rel="noopener">
+    <a href="/rss.xml" target="_blank" rel="noopener noreferrer">
       <img
         src="https://cdn.jsdelivr.net/npm/simple-icons@latest/icons/rss.svg"
         alt="RSS"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,8 +12,9 @@ const frontmatter = {
     tagline: 'Boldly going where no hacker has gone before<br />Probably doing a <a href="https://careerlimitingmaneuver.com" target="_blank" rel="noopener noreferrer">Career Limiting Maneuver</a>',
     image: { file: tylerImage, alt: 'Tyler Staut head-shot' },
     actions: [
-      { text: 'Read my Blog', link: '/blog/', icon: 'rss', variant: 'secondary' },
-      { text: 'Dive into my Docs', link: '/notes/', icon: 'right-arrow' }
+      { text: 'Read my Blog', link: '/blog/', icon: 'right-arrow', variant: 'secondary' },
+      { text: 'Dive into my Docs', link: '/notes/', icon: 'right-arrow' },
+      { text: 'RSS Feed', link: '/rss.xml', icon: 'rss', variant: 'secondary' }
     ]
   }
 };

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,9 +12,8 @@ const frontmatter = {
     tagline: 'Boldly going where no hacker has gone before<br />Probably doing a <a href="https://careerlimitingmaneuver.com" target="_blank" rel="noopener noreferrer">Career Limiting Maneuver</a>',
     image: { file: tylerImage, alt: 'Tyler Staut head-shot' },
     actions: [
-      { text: 'Read my Blog', link: '/blog/', icon: 'right-arrow', variant: 'secondary' },
+      { text: 'Read my Blog', link: '/blog/', icon: 'rss', variant: 'secondary' },
       { text: 'Dive into my Docs', link: '/notes/', icon: 'right-arrow' },
-      { text: 'RSS Feed', link: '/rss.xml', icon: 'rss', variant: 'secondary' }
     ]
   }
 };

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,0 +1,23 @@
+import rss from '@astrojs/rss';
+import { getCollection } from 'astro:content';
+
+export async function GET(context) {
+  const posts = await getCollection('blog');
+  const sortedPosts = posts
+    .filter((post) => post.data.title && post.data.publishDate)
+    .sort(
+      (a, b) => new Date(b.data.publishDate).getTime() - new Date(a.data.publishDate).getTime()
+    );
+
+  return rss({
+    title: 'Tyler Staut - Blog',
+    description: 'Latest blog posts from Tyler Staut',
+    site: context.site ?? 'https://tylerstaut.com',
+    items: sortedPosts.map((post) => ({
+      title: post.data.title,
+      description: post.data.description,
+      pubDate: new Date(post.data.publishDate),
+      link: `/blog/${post.slug}/`,
+    })),
+  });
+}


### PR DESCRIPTION
## Summary
- generate blog RSS feed from `blog` collection
- link RSS feed in site head

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_688fd7ae57008322a2b78e3770ce67d5