### PR TITLE
refactor: move inline styles into classes

### DIFF
--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -17,18 +17,22 @@ const frontmatter = { title, tableOfContents: false };
 ---
 <StarlightPage frontmatter={frontmatter} hasSidebar={false}>
   {heroImage && (
-    <img src={heroImage} alt={title} style="width:100%;object-fit:cover;" />
+    <img src={heroImage} alt={title} class="post-hero-image" />
   )}
-  <header style="margin-bottom:1rem;">
+  <header class="post-header">
     {(author?.avatar || author?.name) && (
-      <div style="display:flex;align-items:center;gap:0.5rem;">
+      <div class="post-author">
         {author?.avatar && (
-          <img src={author.avatar} alt={author.name ?? 'Author'} style="width:40px;height:40px;border-radius:50%;" />
+          <img
+            src={author.avatar}
+            alt={author.name ?? 'Author'}
+            class="author-avatar"
+          />
         )}
         {author?.name && <span>{author.name}</span>}
       </div>
     )}
-    <div style="display:flex;flex-wrap:wrap;gap:0.5rem;font-size:0.875rem;color:var(--sl-color-text-secondary);">
+    <div class="post-meta">
       {readingTime && <span>{readingTime}</span>}
     </div>
   </header>
@@ -36,3 +40,34 @@ const frontmatter = { title, tableOfContents: false };
     <slot />
   </article>
 </StarlightPage>
+
+<style>
+  .post-hero-image {
+    width: 100%;
+    object-fit: cover;
+  }
+
+  .post-header {
+    margin-bottom: var(--sl-spacing-md, 1rem);
+  }
+
+  .post-author {
+    display: flex;
+    align-items: center;
+    gap: var(--sl-spacing-sm, 0.5rem);
+  }
+
+  .author-avatar {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+  }
+
+  .post-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--sl-spacing-sm, 0.5rem);
+    font-size: var(--sl-text-sm, 0.875rem);
+    color: var(--sl-color-text-secondary);
+  }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -85,29 +85,49 @@ const frontmatter = {
     </Card>
 
     <Card class="flex flex-col" title="Contact" icon="email">
-      <small class="flex items-center gap-2 flex-row whitespace-nowrap w-full" style="display:block;">
-        <span style="display:flex;align-items:center;gap:0.75rem;">
-          <a href="https://linkedin.com/in/Tyler-Staut" class="inline-flex items-center no-underline" style="color:inherit;" aria-label="LinkedIn">
-            <Icon name="simple-icons:linkedin" size="30" style="color:currentColor;" />
-          </a>
-          <a href="https://github.com/Tyler-Staut" class="inline-flex items-center no-underline" style="color:inherit;" aria-label="GitHub">
-            <Icon name="simple-icons:github" size="30" style="color:currentColor;" />
-          </a>
-          <a href="https://bsky.app/profile/tylerstaut.com" class="inline-flex items-center no-underline" style="color:inherit;" aria-label="Bluesky">
-            <Icon name="simple-icons:bluesky" size="30" style="color:currentColor;" />
-          </a>
-        </span>
+      <small class="contact-icons">
+        <a
+          href="https://linkedin.com/in/Tyler-Staut"
+          class="inline-flex items-center no-underline"
+          aria-label="LinkedIn"
+        >
+          <Icon name="simple-icons:linkedin" size="30" />
+        </a>
+        <a
+          href="https://github.com/Tyler-Staut"
+          class="inline-flex items-center no-underline"
+          aria-label="GitHub"
+        >
+          <Icon name="simple-icons:github" size="30" />
+        </a>
+        <a
+          href="https://bsky.app/profile/tylerstaut.com"
+          class="inline-flex items-center no-underline"
+          aria-label="Bluesky"
+        >
+          <Icon name="simple-icons:bluesky" size="30" />
+        </a>
       </small>
     </Card>
   </CardGrid>
 
   <section class="latest-bluesky">
-    <h2 style="display: flex; color:inherit; align-items: center; gap: 0.5em; font-size: 1.5rem;">
-      <img src="https://cdn.jsdelivr.net/npm/simple-icons@latest/icons/bluesky.svg" alt="Bluesky" style="width: 1.5em; height: 1.5em; vertical-align: middle;" />
+    <h2 class="bsky-header">
+      <img
+        src="https://cdn.jsdelivr.net/npm/simple-icons@latest/icons/bluesky.svg"
+        alt="Bluesky"
+      />
       <span>From Bluesky</span>
     </h2>
-    <p style="color:inherit;" margin-top: 0; margin-bottom: 1rem; font-size: 1rem;">
-      A peek at my latest posts on <a href="https://bsky.app/profile/tylerstaut.com" target="_blank" rel="noopener noreferrer" style="color:inherit; text-decoration: underline;">Bluesky</a>.
+    <p class="bsky-description">
+      A peek at my latest posts on
+      <a
+        href="https://bsky.app/profile/tylerstaut.com"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Bluesky
+      </a>.
     </p>
     {posts.length === 0 ? (
       <p>No Bluesky posts yet.</p>
@@ -135,7 +155,7 @@ const frontmatter = {
 <style>
   .latest-blog,
   .latest-bluesky {
-    margin-top: 2rem;
+    margin-top: var(--sl-spacing-xl, 2rem);
   }
 
   .post-list {
@@ -145,11 +165,48 @@ const frontmatter = {
   }
 
   .post-list li {
-    margin-bottom: 0.5rem;
+    margin-bottom: var(--sl-spacing-sm, 0.5rem);
   }
 
   .archive-link {
     text-align: right;
+  }
+
+  .contact-icons {
+    display: flex;
+    align-items: center;
+    gap: var(--sl-spacing-md, 0.75rem);
+    color: inherit;
+  }
+
+  .contact-icons a {
+    color: inherit;
+  }
+
+  .bsky-header {
+    display: flex;
+    align-items: center;
+    gap: var(--sl-spacing-sm, 0.5rem);
+    font-size: var(--sl-text-2xl, 1.5rem);
+    color: inherit;
+  }
+
+  .bsky-header img {
+    width: 1.5em;
+    height: 1.5em;
+    vertical-align: middle;
+  }
+
+  .bsky-description {
+    color: inherit;
+    margin-top: 0;
+    margin-bottom: var(--sl-spacing-md, 1rem);
+    font-size: var(--sl-text-base, 1rem);
+  }
+
+  .bsky-description a {
+    color: inherit;
+    text-decoration: underline;
   }
 
   .bsky-list {
@@ -157,7 +214,7 @@ const frontmatter = {
     margin: 0;
     padding: 0;
     display: grid;
-    gap: 1rem;
+    gap: var(--sl-spacing-md, 1rem);
   }
 
   @media (min-width: 50rem) {
@@ -172,7 +229,7 @@ const frontmatter = {
     border-radius: 0.5rem;
     overflow: hidden;
     min-height: 10rem;
-    padding: 1rem;
+    padding: var(--sl-spacing-md, 1rem);
     color: var(--sl-color-white);
     text-decoration: none;
     background-color: var(--sl-color-gray-6);
@@ -198,8 +255,8 @@ const frontmatter = {
 
   .bsky-card time {
     display: block;
-    margin-top: 0.5rem;
-    font-size: 0.875rem;
+    margin-top: var(--sl-spacing-sm, 0.5rem);
+    font-size: var(--sl-text-sm, 0.875rem);
     color: var(--sl-color-gray-3);
   }
 </style>


### PR DESCRIPTION
## Summary
- remove inline style attributes from contact icons and Bluesky section
- add post layout classes for hero image, header, author info, and metadata

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_688ff33c06188322afacd541be66ec67